### PR TITLE
fix: added serialization support

### DIFF
--- a/src/main/java/de/f0rce/ace/AceEditor.java
+++ b/src/main/java/de/f0rce/ace/AceEditor.java
@@ -43,12 +43,12 @@ import de.f0rce.ace.util.AceSelection;
 import de.f0rce.ace.util.AceStaticWordCompleter;
 
 /** @author David "F0rce" Dodlek */
-@SuppressWarnings("serial")
 @Tag("lit-ace")
 @NpmPackage(value = "@f0rce/lit-ace", version = "1.11.1")
 @JsModule("./@f0rce/lit-ace/lit-ace.js")
 public class AceEditor extends Component implements HasSize, HasStyle, Focusable<AceEditor> {
-
+  private static final long serialVersionUID = -1271032625249326755L;
+  
   public static final String DEFAULT_STATIC_CATEGORY = "keyword";
   public static final String DEFAULT_DYNAMIC_CATEGORY = "dynamic";
 

--- a/src/main/java/de/f0rce/ace/events/AceBlurChanged.java
+++ b/src/main/java/de/f0rce/ace/events/AceBlurChanged.java
@@ -9,10 +9,10 @@ import de.f0rce.ace.util.AceSelection;
 import elemental.json.JsonObject;
 
 /** @author David "F0rce" Dodlek */
-@SuppressWarnings("serial")
 @DomEvent("editor-blur")
 public class AceBlurChanged extends ComponentEvent<AceEditor> {
-
+  private static final long serialVersionUID = -4363961168257667085L;
+  
   private String value;
   private AceSelection selection;
   private AceCursorPosition cursorPosition;

--- a/src/main/java/de/f0rce/ace/events/AceChanged.java
+++ b/src/main/java/de/f0rce/ace/events/AceChanged.java
@@ -6,9 +6,10 @@ import com.vaadin.flow.component.EventData;
 import de.f0rce.ace.AceEditor;
 
 /** @author Jean-Christophe "jcgueriaud1" Gueriaud */
-@SuppressWarnings("serial")
 @DomEvent("editor-change")
 public class AceChanged extends ComponentEvent<AceEditor> {
+  private static final long serialVersionUID = -7037867260485774128L;
+  
   private String value;
 
   public AceChanged(

--- a/src/main/java/de/f0rce/ace/events/AceForceSyncDomEvent.java
+++ b/src/main/java/de/f0rce/ace/events/AceForceSyncDomEvent.java
@@ -9,10 +9,10 @@ import de.f0rce.ace.util.AceSelection;
 import elemental.json.JsonObject;
 
 /** @author David "F0rce" Dodlek */
-@SuppressWarnings("serial")
 @DomEvent("force-sync")
 public class AceForceSyncDomEvent extends ComponentEvent<AceEditor> {
-
+  private static final long serialVersionUID = -2860752603650092426L;
+  
   private String value;
   private AceSelection selection;
   private AceCursorPosition cursorPosition;

--- a/src/main/java/de/f0rce/ace/events/AceForceSyncEvent.java
+++ b/src/main/java/de/f0rce/ace/events/AceForceSyncEvent.java
@@ -6,9 +6,9 @@ import de.f0rce.ace.util.AceCursorPosition;
 import de.f0rce.ace.util.AceSelection;
 
 /** @author David "F0rce" Dodlek */
-@SuppressWarnings("serial")
 public class AceForceSyncEvent extends ComponentEvent<AceEditor> {
-
+  private static final long serialVersionUID = -1096750808791222529L;
+  
   private String value;
   private AceSelection selection;
   private AceCursorPosition cursorPosition;

--- a/src/main/java/de/f0rce/ace/events/AceHTMLGeneratedEvent.java
+++ b/src/main/java/de/f0rce/ace/events/AceHTMLGeneratedEvent.java
@@ -6,10 +6,10 @@ import com.vaadin.flow.component.EventData;
 import de.f0rce.ace.AceEditor;
 
 /** @author David "F0rce" Dodlek */
-@SuppressWarnings("serial")
 @DomEvent("html-generated")
 public class AceHTMLGeneratedEvent extends ComponentEvent<AceEditor> {
-
+  private static final long serialVersionUID = -6068162857504589793L;
+  
   private String html;
 
   public AceHTMLGeneratedEvent(

--- a/src/main/java/de/f0rce/ace/events/AceReady.java
+++ b/src/main/java/de/f0rce/ace/events/AceReady.java
@@ -5,9 +5,9 @@ import com.vaadin.flow.component.DomEvent;
 import de.f0rce.ace.AceEditor;
 
 /** @author David "F0rce" Dodlek */
-@SuppressWarnings("serial")
 @DomEvent("editor-ready")
 public class AceReady extends ComponentEvent<AceEditor> {
+  private static final long serialVersionUID = -4675596061674438690L;
 
   public AceReady(AceEditor source, boolean fromClient) {
     super(source, fromClient);

--- a/src/main/java/de/f0rce/ace/events/AceSelectionChanged.java
+++ b/src/main/java/de/f0rce/ace/events/AceSelectionChanged.java
@@ -9,10 +9,10 @@ import de.f0rce.ace.util.AceSelection;
 import elemental.json.JsonObject;
 
 /** @author David "F0rce" Dodlek */
-@SuppressWarnings("serial")
 @DomEvent("editor-selection")
 public class AceSelectionChanged extends ComponentEvent<AceEditor> {
-
+  private static final long serialVersionUID = 5663784972918776280L;
+  
   private AceSelection selection;
   private AceCursorPosition cursorPosition;
 

--- a/src/main/java/de/f0rce/ace/events/AceValueChanged.java
+++ b/src/main/java/de/f0rce/ace/events/AceValueChanged.java
@@ -4,9 +4,9 @@ import com.vaadin.flow.component.ComponentEvent;
 import de.f0rce.ace.AceEditor;
 
 /** @author David "F0rce" Dodlek */
-@SuppressWarnings("serial")
 public class AceValueChanged extends ComponentEvent<AceEditor> {
-
+  private static final long serialVersionUID = -6041775847653361784L;
+  
   private String value;
 
   public AceValueChanged(AceEditor source, boolean fromClient, String value) {

--- a/src/main/java/de/f0rce/ace/util/AceCursorPosition.java
+++ b/src/main/java/de/f0rce/ace/util/AceCursorPosition.java
@@ -1,13 +1,16 @@
 package de.f0rce.ace.util;
 
+import java.io.Serializable;
+
 import de.f0rce.ace.events.AceBlurChanged;
 import de.f0rce.ace.events.AceForceSyncDomEvent;
 import de.f0rce.ace.events.AceSelectionChanged;
 import elemental.json.JsonObject;
 
 /** @author David "F0rce" Dodlek */
-public class AceCursorPosition {
-
+public class AceCursorPosition implements Serializable {
+  private static final long serialVersionUID = -7196877713512018421L;
+  
   private int row;
   private int column;
   private int index;

--- a/src/main/java/de/f0rce/ace/util/AceCustomMode.java
+++ b/src/main/java/de/f0rce/ace/util/AceCustomMode.java
@@ -1,13 +1,15 @@
 package de.f0rce.ace.util;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class AceCustomMode {
-
+public class AceCustomMode implements Serializable {
+  private static final long serialVersionUID = 5969018639805872099L;
+  
   private Map<String, List<AceCustomModeRule>> states = new HashMap<>();
 
   /**

--- a/src/main/java/de/f0rce/ace/util/AceCustomModeRule.java
+++ b/src/main/java/de/f0rce/ace/util/AceCustomModeRule.java
@@ -1,5 +1,6 @@
 package de.f0rce.ace.util;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -15,8 +16,9 @@ import de.f0rce.ace.enums.AceCustomModeTokens;
  * @see <a href="https://github.com/F0rce/ace/issues">GitHub Repository</a>
  * @author David "F0rce" Dodlek
  */
-public class AceCustomModeRule {
-
+public class AceCustomModeRule implements Serializable {
+  private static final long serialVersionUID = 6065223542999115466L;
+  
   private Object token;
   private String regex;
   private String next;

--- a/src/main/java/de/f0rce/ace/util/AceDynamicWordCompleter.java
+++ b/src/main/java/de/f0rce/ace/util/AceDynamicWordCompleter.java
@@ -1,5 +1,6 @@
 package de.f0rce.ace.util;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import com.google.gson.Gson;
@@ -7,8 +8,9 @@ import de.f0rce.ace.AceEditor;
 import de.f0rce.ace.interfaces.IAceWordCompleter;
 
 /** @author David "F0rce" Dodlek */
-public class AceDynamicWordCompleter implements IAceWordCompleter {
-
+public class AceDynamicWordCompleter implements IAceWordCompleter, Serializable {
+  private static final long serialVersionUID = -459062900322455876L;
+  
   private Map<String, List<String>> dynamicWords;
   private String seperator;
   private String category;

--- a/src/main/java/de/f0rce/ace/util/AceMarker.java
+++ b/src/main/java/de/f0rce/ace/util/AceMarker.java
@@ -1,11 +1,14 @@
 package de.f0rce.ace.util;
 
 import de.f0rce.ace.enums.AceMarkerColor;
+
+import java.io.Serializable;
 import java.util.UUID;
 
 /** @author David "F0rce" Dodlek */
-public class AceMarker {
-
+public class AceMarker implements Serializable {
+  private static final long serialVersionUID = -5306622806411718397L;
+  
   private String id;
   private int rowStart;
   private int from;

--- a/src/main/java/de/f0rce/ace/util/AceSelection.java
+++ b/src/main/java/de/f0rce/ace/util/AceSelection.java
@@ -1,13 +1,16 @@
 package de.f0rce.ace.util;
 
+import java.io.Serializable;
+
 import de.f0rce.ace.events.AceBlurChanged;
 import de.f0rce.ace.events.AceForceSyncDomEvent;
 import de.f0rce.ace.events.AceSelectionChanged;
 import elemental.json.JsonObject;
 
 /** @author David "F0rce" Dodlek */
-public class AceSelection {
-
+public class AceSelection implements Serializable {
+  private static final long serialVersionUID = -4232816207419671039L;
+  
   private int startRow;
   private int startColumn;
   private int endRow;

--- a/src/main/java/de/f0rce/ace/util/AceStaticWordCompleter.java
+++ b/src/main/java/de/f0rce/ace/util/AceStaticWordCompleter.java
@@ -1,13 +1,15 @@
 package de.f0rce.ace.util;
 
+import java.io.Serializable;
 import java.util.List;
 import com.google.gson.Gson;
 import de.f0rce.ace.AceEditor;
 import de.f0rce.ace.interfaces.IAceWordCompleter;
 
 /** @author David "F0rce" Dodlek */
-public class AceStaticWordCompleter implements IAceWordCompleter {
-
+public class AceStaticWordCompleter implements IAceWordCompleter, Serializable {
+  private static final long serialVersionUID = -1311138752178496479L;
+  
   private List<String> words;
   private String category;
   private boolean keepCompleters = false;


### PR DESCRIPTION
All components added into a j2ee HttpSession must to be serializable.
This is also needed when using the editor in clustered environments to migrate active sessions between nodes.