### PR TITLE
Extend custom mode API with start/end and keyword mapping

### DIFF
--- a/src/main/java/de/f0rce/ace/enums/AceCustomModeTokens.java
+++ b/src/main/java/de/f0rce/ace/enums/AceCustomModeTokens.java
@@ -101,6 +101,8 @@ public enum AceCustomModeTokens {
   /** the name of an attribute (mainly in tags) */
   ENTITY_OTHER_ATTRIBUTE_NAME("entity.other.attribute-name"),
 
+  IDENTIFIER("identifier"),
+
   /** stuff which is "invalid" */
   INVALID("invalid"),
 

--- a/src/main/java/de/f0rce/ace/util/AceCustomModeRule.java
+++ b/src/main/java/de/f0rce/ace/util/AceCustomModeRule.java
@@ -2,6 +2,7 @@ package de.f0rce.ace.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 import de.f0rce.ace.enums.AceCustomModeTokens;
 
@@ -19,6 +20,8 @@ public class AceCustomModeRule {
 
   private Object token;
   private String regex;
+  private String start;
+  private String end;
   private String next;
   private String defaultToken;
 
@@ -49,6 +52,15 @@ public class AceCustomModeRule {
             .collect(Collectors.toCollection(ArrayList<String>::new));
   }
 
+  public void setKeywordMapper(Map<AceCustomModeTokens, String> map, AceCustomModeTokens defaultToken, boolean ignoreCase, String splitChar) {
+    this.token = Map.of(
+            "map", map.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().getToken(), Map.Entry::getValue)),
+            "defaultToken", defaultToken.getToken(),
+            "ignoreCase", ignoreCase,
+            "splitChar", splitChar
+    );
+  }
+
   /** @return {@link ArrayList} */
   public ArrayList<AceCustomModeTokens> getTokens() {
     if (this.token instanceof ArrayList<?>) {
@@ -76,6 +88,26 @@ public class AceCustomModeRule {
     return this.regex;
   }
 
+  /** @param start {@link String} */
+  public void setStart(String start) {
+    this.start = start;
+  }
+
+  /** @return {@link String} */
+  public String getStart() {
+    return this.start;
+  }
+
+  /** @param end {@link String} */
+  public void setEnd(String end) {
+    this.end = end;
+  }
+
+  /** @return {@link String} */
+  public String getEnd() {
+    return this.end;
+  }
+  
   /** @param next {@link String} */
   public void setNext(String next) {
     this.next = next;

--- a/src/main/resources/META-INF/resources/frontend/@f0rce/lit-ace/lit-ace.js
+++ b/src/main/resources/META-INF/resources/frontend/@f0rce/lit-ace/lit-ace.js
@@ -1271,6 +1271,23 @@ class LitAce extends LitElement {
     var customModeFunction = function () {
       this.$rules = parsed.states;
 
+      // Convert objects to keyword mappers
+      for (var key in this.$rules) {
+        var state = this.$rules[key];
+        for (var i = 0; i < state.length; i++) {
+          var rule = state[i];
+          let token = rule.token;
+          if (typeof token === "object") {
+            rule.token = this.createKeywordMapper(
+                token.map,
+                token.defaultToken,
+                token.ignoreCase,
+                token.splitChar
+            )
+          }
+        }
+      }
+
       this.normalizeRules();
     }
 


### PR DESCRIPTION
This PR adds two extra capabilities to the custom mode rule Java API:
- start/end to support things like block comments
- keyword mapper support

With these two changes modes like the SQL mode can be completely defined via the Java API.