### PR TITLE
fix: support adding multiple markers simultaneously

### DIFF
--- a/src/main/java/de/f0rce/ace/AceEditor.java
+++ b/src/main/java/de/f0rce/ace/AceEditor.java
@@ -1052,21 +1052,9 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
               currentSelection.getEndColumn(),
               color);
 
-      this.getElement()
-          .setProperty(
-              "marker",
-              marker.getRowStart()
-                  + "|"
-                  + marker.getFrom()
-                  + "|"
-                  + marker.getRowEnd()
-                  + "|"
-                  + marker.getTo()
-                  + "|"
-                  + marker.getAceMarkerColor().toString()
-                  + "|"
-                  + marker.getID());
       this.markers.add(marker);
+      this.getElement().callJsFunction("addMarker", marker.toJSON());
+
       return marker;
     }
     return null;
@@ -1096,21 +1084,8 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
               color,
               alias);
 
-      this.getElement()
-          .setProperty(
-              "marker",
-              marker.getRowStart()
-                  + "|"
-                  + marker.getFrom()
-                  + "|"
-                  + marker.getRowEnd()
-                  + "|"
-                  + marker.getTo()
-                  + "|"
-                  + marker.getAceMarkerColor().toString()
-                  + "|"
-                  + marker.getID());
       this.markers.add(marker);
+      this.getElement().callJsFunction("addMarker", marker.toJSON());
       return marker;
     }
     return null;
@@ -1146,22 +1121,8 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
     }
 
     AceMarker marker = new AceMarker(rowStart, from, rowEnd, to, color);
-
-    this.getElement()
-        .setProperty(
-            "marker",
-            marker.getRowStart()
-                + "|"
-                + marker.getFrom()
-                + "|"
-                + marker.getRowEnd()
-                + "|"
-                + marker.getTo()
-                + "|"
-                + marker.getAceMarkerColor().toString()
-                + "|"
-                + marker.getID());
     this.markers.add(marker);
+    this.getElement().callJsFunction("addMarker", marker.toJSON());
     return marker;
   }
 
@@ -1196,22 +1157,8 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
     }
 
     AceMarker marker = new AceMarker(rowStart, from, rowEnd, to, color, alias);
-
-    this.getElement()
-        .setProperty(
-            "marker",
-            marker.getRowStart()
-                + "|"
-                + marker.getFrom()
-                + "|"
-                + marker.getRowEnd()
-                + "|"
-                + marker.getTo()
-                + "|"
-                + marker.getAceMarkerColor().toString()
-                + "|"
-                + marker.getID());
     this.markers.add(marker);
+    this.getElement().callJsFunction("addMarker", marker.toJSON());
     return marker;
   }
 
@@ -1221,21 +1168,8 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
    * @param marker {@link AceMarker}
    */
   public void addMarker(AceMarker marker) {
-    this.getElement()
-        .setProperty(
-            "marker",
-            marker.getRowStart()
-                + "|"
-                + marker.getFrom()
-                + "|"
-                + marker.getRowEnd()
-                + "|"
-                + marker.getTo()
-                + "|"
-                + marker.getAceMarkerColor().toString()
-                + "|"
-                + marker.getID());
     this.markers.add(marker);
+    this.getElement().callJsFunction("addMarker", marker.toJSON());
   }
 
   /**
@@ -1256,9 +1190,9 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
    * @param marker {@link AceMarker}
    */
   public void removeMarker(AceMarker marker) {
-    for (AceMarker mar : this.markers) {
+    for (AceMarker mar : new ArrayList<>(this.markers)) {
       if (mar.getID().equals(marker.getID())) {
-        this.getElement().setProperty("rmMarker", marker.getID());
+        this.getElement().callJsFunction("rmMarker", marker.getID());
         this.markers.remove(marker);
       }
     }
@@ -1272,9 +1206,9 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
    * @param id {@link String}
    */
   public void removeMarkerByID(String id) {
-    for (AceMarker mar : this.markers) {
+    for (AceMarker mar : new ArrayList<>(this.markers)) {
       if (mar.getID().equals(id)) {
-        this.getElement().setProperty("rmMarker", id);
+        this.getElement().callJsFunction("rmMarker", id);
         this.markers.remove(mar);
       }
     }
@@ -1288,9 +1222,9 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
    * @param alias {@link String}
    */
   public void removeMarkerByAlias(String alias) {
-    for (AceMarker mar : this.markers) {
+    for (AceMarker mar : new ArrayList<>(this.markers)) {
       if (mar.getAlias().equals(alias)) {
-        this.getElement().setProperty("rmMarker", mar.getID());
+        this.getElement().callJsFunction("rmMarker", mar.getID());
         this.markers.remove(mar);
       }
     }
@@ -1298,7 +1232,7 @@ public class AceEditor extends Component implements HasSize, HasStyle, Focusable
 
   /** Removes every marker from the editor. */
   public void removeAllMarkers() {
-    this.getElement().setProperty("rmMarker", "all" + UUID.randomUUID().toString());
+    this.getElement().callJsFunction("rmMarker", "all" + UUID.randomUUID());
     this.markers = new ArrayList<>();
   }
 

--- a/src/main/java/de/f0rce/ace/util/AceMarker.java
+++ b/src/main/java/de/f0rce/ace/util/AceMarker.java
@@ -171,4 +171,27 @@ public class AceMarker implements Serializable {
         + this.alias
         + "]";
   }
+
+  public String toJSON() {
+    StringBuilder builder = new StringBuilder();
+
+    builder.append("{");
+    builder.append("\"id\": \"" + this.getID() + "\", ");
+    builder.append("\"color\": \"" + this.getAceMarkerColor().toString() + "\", ");
+    builder.append(
+            "\"start\": { \"row\": "
+                    + this.getRowStart()
+                    + ", \"from\": "
+                    + this.getFrom()
+                    + " }, ");
+    builder.append(
+            "\"end\": { \"row\": "
+                    + this.getRowEnd()
+                    + ", \"to\": "
+                    + this.getTo()
+                    + " }");
+    builder.append("}");
+
+    return builder.toString();
+  }
 }

--- a/src/main/resources/META-INF/resources/frontend/@f0rce/lit-ace/lit-ace.js
+++ b/src/main/resources/META-INF/resources/frontend/@f0rce/lit-ace/lit-ace.js
@@ -38,9 +38,6 @@ class LitAce extends LitElement {
       displayIndentGuides: { type: Boolean },
       highlightSelectedWord: { type: Boolean },
       useWorker: { type: Boolean },
-      marker: { type: String }, // TODO: remove this, use markerList instead
-      markerList: { type: Array }, // TODO: kepp this, backend should create a json with all markers
-      rmMarker: { type: String }, // TODO: use method
       statusbarEnabled: { type: Boolean },
       enableSnippets: { type: Boolean },
     };
@@ -67,9 +64,6 @@ class LitAce extends LitElement {
     this.displayIndentGuides = false;
     this.highlightSelectedWord = false;
     this.useWorker = false;
-    this.marker = "-|-|-|-|-|-";
-    this.markerList = { markers: [] };
-    this.rmMarker = "";
     this.statusbarEnabled = true;
     this.enableSnippets = false;
   }
@@ -197,6 +191,8 @@ class LitAce extends LitElement {
     this.snippetManager = ace.require("ace/snippets").snippetManager;
 
     this._customModes = new Map();
+
+    this._activeMarkers = new Map();
 
     let self = this;
 
@@ -472,52 +468,54 @@ class LitAce extends LitElement {
     this.editor.renderer.setShowGutter(this.showGutter);
   }
 
-  markerChanged() {
+  addMarker(json) {
     if (this.editor == undefined) {
-      return;
+      this.addEventListener("editor-ready", () => this._addMarker(json), {
+        once: true,
+      });
+    } else {
+      this._addMarker(json);
     }
-
-    if (this.marker == "-|-|-|-|-|-") {
-      return;
-    }
-
-    const markerRaw = this.marker;
-    const rawSplit = markerRaw.split("|");
-    const markerRowStart = parseInt(rawSplit[0]);
-    const markerFrom = parseInt(rawSplit[1]);
-    const markerRowEnd = parseInt(rawSplit[2]);
-    const markerTo = parseInt(rawSplit[3]);
-    const markerColor = String(rawSplit[4]);
-    const uuid = String(rawSplit[5]);
-
-    const Range = ace.require("ace/range").Range;
-    const _range = this.editor.session.addMarker(
-      new Range(markerRowStart, markerFrom, markerRowEnd, markerTo),
-      markerColor,
-      "text",
-      false
-    );
-    this.markerList.markers.push({ uuid: uuid, rangeid: _range });
   }
 
-  rmMarkerChanged() {
-    if (this.rmMarker == "") {
-      return;
-    }
+  /** @private */
+  _addMarker(json) {
+    const marker = JSON.parse(json);
 
-    if (this.rmMarker.includes("all")) {
-      for (var i in this.markerList.markers) {
-        const del = this.markerList.markers[i].rangeid;
-        this.editor.getSession().removeMarker(del);
-        delete this.markerList.markers[i];
-      }
+    if(!this._activeMarkers.has(marker.id)) {
+      const markerRowStart = marker.start.row;
+      const markerFrom = marker.start.from;
+      const markerRowEnd = marker.end.row;
+      const markerTo = marker.end.to;
+      const markerColor = marker.color;
+
+      const Range = ace.require("ace/range").Range;
+      const _range = this.editor.session.addMarker(
+          new Range(markerRowStart, markerFrom, markerRowEnd, markerTo),
+          markerColor,
+          "text",
+          false
+      );
+      this._activeMarkers.set(marker.id, _range);
+    }
+  }
+
+  rmMarker(id) {
+    if (this.editor == undefined) {
+      this.addEventListener("editor-ready", () => this._rmMarker(id), {
+        once: true,
+      });
     } else {
-      for (var i in this.markerList.markers) {
-        if (this.markerList.markers[i].uuid == this.rmMarker) {
-          const del = this.markerList.markers[i].rangeid;
-          this.editor.getSession().removeMarker(del);
-          delete this.markerList.markers[i];
-        }
+      this._rmMarker(id);
+    }
+  }
+
+  /** @private */
+  _rmMarker(id) {
+    for (const [key, value] of this._activeMarkers) {
+      if (id.includes("all") || key == id) {
+        this.editor.getSession().removeMarker(value);
+        this._activeMarkers.delete(key);
       }
     }
   }


### PR DESCRIPTION
This PR improves the marker functionality by enabling support for adding multiple highlight markers at the same time.

Currently, when multiple markers are added, the behavior is inconsistent: some markers may be ignored and not rendered in the editor. This leads to indeterminate results and limits the usability of the component in more advanced scenarios.

This change ensures that all markers are properly handled and displayed when added simultaneously.

This is particularly useful for use cases such as diff visualization, where multiple highlight markers are needed to represent differences between two files.